### PR TITLE
perf: replace string concatenation with table.concat

### DIFF
--- a/lua/coop/uv-utils.lua
+++ b/lua/coop/uv-utils.lua
@@ -92,15 +92,17 @@ end
 ---@param self StreamReader
 ---@return string data The data read from the stream.
 M.StreamReader.read_until_eof = function(self)
-	local data = ""
+	local data = {}
 
 	local chunk = self:read()
+	local i = 1
 	while chunk ~= nil do
-		data = data .. chunk
+		data[i] = chunk
+		i = i + 1
 		chunk = self:read()
 	end
 
-	return data
+	return table.concat(data, "")
 end
 
 --- Closes the stream reader.


### PR DESCRIPTION
First of all, thanks for the great plugin! When I discovered coop, I immediately switched from plenary's async module for a plugin I'm writing. My use case involved subprocesses, and while I was taking a look at the source I noticed an inefficiency in `read_until_eof`.

String concatenation is slow in lua, because all strings are interned - so concatenation always results in a new allocation. The solution is to instead append all chunks into an array, then concatenate once at the end with `table.concat`. The "About Strings" section of [this](https://www.lua.org/gems/sample.pdf) document does a better job explaining.

Here are some example functions that demonstrate this:
```lua
local function a()
  local data = ""
  for i = 1, 10000 do
    data = data .. "AAAAAAAAAA"
  end
  return data
end

local function b()
  local data = {}
  for i = 1, 10000 do
    data[i] = "AAAAAAAAAA"
  end
  return table.concat(data, "")
end
```
For me, `a()` runs in around 60ms while `b()` runs in around 0.04ms.

Note that in the PR I added a separate index variable rather than using `data[#data + 1]`, which in my testing was around 1.5x slower at 0.07ms.