### PR TITLE
feat: type annotation improvements

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -3,6 +3,7 @@
   "Lua.runtime.version": "LuaJIT",
   "Lua.diagnostics.globals": ["vim"],
   "workspace.library": [
+    "$VIMRUNTIME/lua/vim",
     "./lua",
     "${3rd}/busted/library",
     "${3rd}/luassert/library",

--- a/.luarc.json
+++ b/.luarc.json
@@ -1,12 +1,11 @@
 {
   "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
   "Lua.runtime.version": "LuaJIT",
-  "Lua.diagnostics.globals": [
-    "vim",
-  ],
+  "Lua.diagnostics.globals": ["vim"],
   "workspace.library": [
     "./lua",
     "${3rd}/busted/library",
     "${3rd}/luassert/library",
-  ],
+    "${3rd}/luv/library"
+  ]
 }

--- a/README.md
+++ b/README.md
@@ -140,12 +140,12 @@ A task behaves like a coroutine and comes with its own equivalent functions:
 --- Creates a task from a task function.
 ---
 ---@param task_function @async fun
----@return Task task
+---@return Coop.Task task
 task.create
 
 --- Resumes a task.
 ---
----@param task Task
+---@param task Coop.Task
 ---@param ...
 ---@return boolean success
 ---@return any ... results
@@ -162,13 +162,13 @@ task.yield
 
 --- Returns the task’s status.
 ---
----@param task Task
+---@param task Coop.Task
 ---@return string "running" | "suspended" | "normal" | "dead"
 task.status
 
 --- Returns the running task.
 ---
----@return Task?
+---@return Coop.Task?
 task.running
 ```
 
@@ -191,7 +191,7 @@ A cancel function (which is also a method):
 --- `cancel` resumes the task. It’s like sending a cancellation signal that the task needs to
 --- handle.
 ---
----@param task Task the task to cancel
+---@param task Coop.Task the task to cancel
 ---@return boolean success
 ---@return any ... results
 function task.cancel(task)
@@ -200,14 +200,14 @@ end
 
 --- Unsets the cancellation flag.
 ---
----@param task Task
+---@param task Coop.Task
 function task.unset_cancelled(task)
   -- …
 end
 
 --- Returns whether the task is cancelled.
 ---
----@param task Task
+---@param task Coop.Task
 ---@return boolean is_cancelled
 function task.is_cancelled(task)
   -- …
@@ -240,7 +240,7 @@ task:await(1000, 100) -- Wait for 1s for the task to finish. Check every 100ms
 --- Instead it returns false, err_msg.
 ---
 ---@async
----@param self Task
+---@param self Coop.Task
 ---@return boolean success
 ---@return any ... results
 function task.pawait(self)
@@ -282,7 +282,7 @@ provides utilities for combining task functions and awaitables.
 --- Cancelling the gather will cancel all tasks in the sequence.
 ---
 ---@async
----@param tasks Task[] the list of tasks.
+---@param tasks Coop.Task[] the list of tasks.
 ---@return any ... results
 M.gather = function(tasks) end
 
@@ -321,22 +321,22 @@ M.timeout = function(duration, tf, ...) end
 --- Waits for any of the given tasks to complete.
 ---
 ---@async
----@param tasks Task[]
----@return Task done The first task that completed.
----@return Task[] done The remaining tasks.
+---@param tasks Coop.Task[]
+---@return Coop.Task done The first task that completed.
+---@return Coop.Task[] done The remaining tasks.
 M.await_any = function(tasks) end
 
 --- Awaits all tasks in the list.
 ---
 ---@async
----@param tasks Task[]
+---@param tasks Coop.Task[]
 ---@return table results The results of the tasks.
 M.await_all = function(tasks) end
 
 --- Asynchronously iterates over the given awaitables and waits for each to complete.
 ---
 ---@async
----@param tasks tasks[]
+---@param tasks Coop.Task[]
 M.as_completed = function(tasks) end
 ```
 

--- a/lua/coop/control.lua
+++ b/lua/coop/control.lua
@@ -4,7 +4,7 @@ local M = {}
 local task = require("coop.task")
 local Future = require("coop.future").Future
 
----@alias Awaitable Future|Task
+---@alias Awaitable Coop.Future|Coop.Task
 
 --- Runs tasks in the sequence concurrently.
 ---
@@ -17,7 +17,7 @@ local Future = require("coop.future").Future
 --- Cancelling the gather will cancel all tasks in the sequence.
 ---
 ---@async
----@param tasks Task[] the list of tasks.
+---@param tasks Coop.Task[] the list of tasks.
 ---@return any ... results
 M.gather = function(tasks)
 	local task_count = #tasks

--- a/lua/coop/future.lua
+++ b/lua/coop/future.lua
@@ -8,7 +8,7 @@ local unpack_packed = require("coop.table-utils").unpack_packed
 ---
 --- Futures turn spawned task functions back into task functions as they implement the call operator.
 ---
----@class Future
+---@class Coop.Future
 ---@field done boolean Whether the future is done.
 ---@field results table The results of the coroutine in pcall/coroutine.resume + pack format.
 ---@field queue table The queue of callbacks to be called once the future is done.
@@ -24,7 +24,7 @@ M.Future = {}
 
 --- Creates a new future.
 ---
----@return Future future the new future.
+---@return Coop.Future future the new future.
 M.Future.new = function()
 	local future = { done = false, queue = {} }
 	local meta_future = {
@@ -52,7 +52,7 @@ end
 
 --- Marks the future as done with an error and calls callbacks in the waiting queue.
 ---
----@param self Future the future
+---@param self Coop.Future the future
 ---@param err string the error message
 M.Future.error = function(self, err)
 	if self.done then
@@ -88,7 +88,7 @@ end
 
 --- Waits for the future to be done.
 ---
----@param self Future the future
+---@param self Coop.Future the future
 ---@return boolean success whether the future was successful and the pawait was not cancelled.
 ---@return any ... the results of the task function or an error message.
 M.Future.pawait = function(self)
@@ -102,7 +102,7 @@ end
 --- Rethrows the error if the future ended with an error or the await was cancelled.
 ---
 ---@async
----@param self Future the future
+---@param self Coop.Future the future
 ---@return any ... the results of the task function
 M.Future.await_tf = function(self)
 	local results = pack(self:pawait_tf())
@@ -117,7 +117,7 @@ end
 ---
 --- This calls the callback with the results of the coroutine function when the future is done.
 ---
----@param self Future the future
+---@param self Coop.Future the future
 ---@param cb function The callback to call with the results of the coroutine.
 M.Future.await_cb = function(self, cb)
 	if self.done then
@@ -158,7 +158,7 @@ end
 --- This is a task function that yields until the future is done.
 ---
 ---@async
----@param self Future the future
+---@param self Coop.Future the future
 ---@return boolean success whether the future was successful and the await was not cancelled.
 ---@return any ... the results of the task function or an error message.
 M.Future.pawait_tf = function(self)

--- a/lua/coop/mpsc-queue.lua
+++ b/lua/coop/mpsc-queue.lua
@@ -6,23 +6,23 @@ local M = {}
 --- The queue uses a buffer and its push is always non-blocking.
 --- The pop operation is blocking iff the queue is empty.
 ---
----@class MpscQueue
----@field waiting Task
----@field head? MpscQueueNode
----@field tail? MpscQueueNode
----@field push fun(self: MpscQueue, value: any)
----@field pop async fun(self: MpscQueue): any
----@field empty fun(self: MpscQueue): boolean
+---@class Coop.MpscQueue
+---@field waiting Coop.Task
+---@field head? Coop.MpscQueueNode
+---@field tail? Coop.MpscQueueNode
+---@field push fun(self: Coop.MpscQueue, value: any)
+---@field pop async fun(self: Coop.MpscQueue): any
+---@field empty fun(self: Coop.MpscQueue): boolean
 
----@class MpscQueueNode
+---@class Coop.MpscQueueNode
 ---@field value any
----@field next? MpscQueueNode
+---@field next? Coop.MpscQueueNode
 
 M.MpscQueue = {}
 
 --- Creates a new multiple-producer single-consumer queue.
 ---
----@return MpscQueue
+---@return Coop.MpscQueue
 M.MpscQueue.new = function()
 	local mpsc_queue = { waiting = nil, head = nil, tail = nil }
 	return setmetatable(mpsc_queue, { __index = M.MpscQueue })
@@ -30,7 +30,7 @@ end
 
 --- Pushes a value to the queue.
 ---
----@param self MpscQueue
+---@param self Coop.MpscQueue
 ---@param value any
 M.MpscQueue.push = function(self, value)
 	if self.waiting then
@@ -53,7 +53,7 @@ end
 --- This method yields iff the queue is empty.
 ---
 ---@async
----@param self MpscQueue
+---@param self Coop.MpscQueue
 ---@return any value
 M.MpscQueue.pop = function(self)
 	if self.head == nil then
@@ -84,7 +84,7 @@ end
 
 --- Checks if the queue is empty.
 ---
----@param self MpscQueue
+---@param self Coop.MpscQueue
 ---@return boolean
 M.MpscQueue.empty = function(self)
 	return self.head == nil

--- a/lua/coop/subprocess.lua
+++ b/lua/coop/subprocess.lua
@@ -6,17 +6,17 @@ M.STREAM = "stream"
 
 ---@alias signum integer|string|nil
 
----@class Process
+---@class Coop.Process
 ---@field handle uv.uv_process_t The handle to the process.
 ---@field pid integer The process ID.
----@field stdin uv.uv_pipe_t | StreamWriter The stdin of the process.
----@field stdout uv.uv_pipe_t | StreamReader The stdout of the process.
----@field stderr uv.uv_pipe_t | StreamReader The stderr of the process.
+---@field stdin uv.uv_pipe_t | Coop.StreamWriter The stdin of the process.
+---@field stdout uv.uv_pipe_t | Coop.StreamReader The stdout of the process.
+---@field stderr uv.uv_pipe_t | Coop.StreamReader The stderr of the process.
 ---
 ---@field await async function Waits for the process to finish.
----@field kill fun(self: Process, signal: signum) Kills the process. Returns 0 or fail.
+---@field kill fun(self: Coop.Process, signal: signum) Kills the process. Returns 0 or fail.
 
----@class SpawnOptions
+---@class Coop.SpawnOptions
 ---@field args? table The arguments to pass to the process.
 ---@field stdio? table The stdio configuration for the process.
 ---                    Accepts either same values as vim.uv.spawn, or PIPE or STREAM.
@@ -37,8 +37,8 @@ M.STREAM = "stream"
 --- Uses `vim.uv.spawn` under the hood.
 ---
 ---@param cmd string The command to run.
----@param opts SpawnOptions
----@return Process process The process object.
+---@param opts Coop.SpawnOptions
+---@return Coop.Process process The process object.
 M.spawn = function(cmd, opts)
 	local uv = require("coop.uv")
 	local table_utils = require("coop.table-utils")

--- a/lua/coop/subprocess.lua
+++ b/lua/coop/subprocess.lua
@@ -9,9 +9,9 @@ M.STREAM = "stream"
 ---@class Process
 ---@field handle uv.uv_process_t The handle to the process.
 ---@field pid integer The process ID.
----@field stdin any The stdin of the process.
----@field stdout any The stdout of the process.
----@field stderr any The stderr of the process.
+---@field stdin uv.uv_pipe_t | StreamWriter The stdin of the process.
+---@field stdout uv.uv_pipe_t | StreamReader The stdout of the process.
+---@field stderr uv.uv_pipe_t | StreamReader The stderr of the process.
 ---
 ---@field await async function Waits for the process to finish.
 ---@field kill fun(Process, signum) Kills the process. Returns 0 or fail.

--- a/lua/coop/subprocess.lua
+++ b/lua/coop/subprocess.lua
@@ -14,7 +14,7 @@ M.STREAM = "stream"
 ---@field stderr uv.uv_pipe_t | StreamReader The stderr of the process.
 ---
 ---@field await async function Waits for the process to finish.
----@field kill fun(Process, signum) Kills the process. Returns 0 or fail.
+---@field kill fun(self: Process, signal: signum) Kills the process. Returns 0 or fail.
 
 ---@class SpawnOptions
 ---@field args? table The arguments to pass to the process.
@@ -37,6 +37,7 @@ M.STREAM = "stream"
 --- Uses `vim.uv.spawn` under the hood.
 ---
 ---@param cmd string The command to run.
+---@param opts SpawnOptions
 ---@return Process process The process object.
 M.spawn = function(cmd, opts)
 	local uv = require("coop.uv")

--- a/lua/coop/subprocess.lua
+++ b/lua/coop/subprocess.lua
@@ -7,7 +7,7 @@ M.STREAM = "stream"
 ---@alias signum integer|string|nil
 
 ---@class Process
----@field handle uv_process_t The handle to the process.
+---@field handle uv.uv_process_t The handle to the process.
 ---@field pid integer The process ID.
 ---@field stdin any The stdin of the process.
 ---@field stdout any The stdout of the process.

--- a/lua/coop/task-utils.lua
+++ b/lua/coop/task-utils.lua
@@ -4,8 +4,8 @@ local M = {}
 local pack = require("coop.table-utils").pack
 local task = require("coop.task")
 
----@class CbToTfOpts
----@field on_cancel? fun(table, table) The function to call when the task is cancelled.
+---@class Coop.CbToTfOpts
+---@field on_cancel? fun(args: table, ret: table) The function to call when the task is cancelled.
 ---                                    This can be used to stop allocation of resources.
 ---                                    This function receives packed tables with the original call’s arguments and
 ---                                    the immediately returned values (useful if the function returns a cancellable
@@ -30,7 +30,7 @@ end
 --- the user needs options to handle the eventual cleanup.
 ---
 ---@param f function The function to convert. The callback needs to be its first argument.
----@param opts? CbToTfOpts The clean up options.
+---@param opts? Coop.CbToTfOpts The clean up options.
 ---@return async function tf A task function. Accepts the same arguments as f without the callback.
 ---                          Returns what f has passed to the callback.
 M.cb_to_tf = function(f, opts)
@@ -82,7 +82,7 @@ end
 --- spawn(f_co, ...)() is semantically the same as f_co(...)
 ---
 ---@param f_co function The task function to spawn.
----@return Task task the spawned task
+---@return Coop.Task task the spawned task
 M.spawn = function(f_co, ...)
 	local spawned_task = task.create(f_co)
 	task.resume(spawned_task, ...)

--- a/lua/coop/task.lua
+++ b/lua/coop/task.lua
@@ -11,27 +11,27 @@ local pack = require("coop.table-utils").pack
 --- - The ability to capture errors.
 --- - The ability to cancel and handle cancellation.
 ---
----@class Task
+---@class Coop.Task
 ---@field thread thread the coroutine thread
----@field future Future the future for the coroutine
+---@field future Coop.Future the future for the coroutine
 ---
----@field status fun(Task): string returns the task’s status
----@field resume fun(Task, ...): boolean, ... resumes the task
+---@field status fun(self: Coop.Task): string returns the task’s status
+---@field resume fun(self: Coop.Task, ...): boolean, ... resumes the task
 ---
----@field cancel fun(Task): boolean, ... cancels the task
+---@field cancel fun(self: Coop.Task): boolean, ... cancels the task
 ---@field cancelled boolean true if the user has requested cancellation
----@field is_cancelled fun(Task): boolean returns true if the task is cancelled
----@field unset_cancelled fun(Task) unsets the cancelled flag
+---@field is_cancelled fun(self: Coop.Task): boolean returns true if the task is cancelled
+---@field unset_cancelled fun(self: Coop.Task) unsets the cancelled flag
 ---
 ---@field await function awaits the task
----@field pawait async fun(Task): boolean, ... awaits the task and returns errors
+---@field pawait async fun(self: Coop.Task): boolean, ... awaits the task and returns errors
 
 local running_task = nil
 
 --- Creates a new task.
 ---
 ---@param tf function the task function
----@return Task
+---@return Coop.Task
 M.create = function(tf)
 	local future_m = require("coop.future")
 	local future = future_m.Future.new()
@@ -70,7 +70,7 @@ end
 
 --- Resumes a task with the specified arguments.
 ---
----@param task Task the task to resume
+---@param task Coop.Task the task to resume
 ---@param ... ... the arguments
 ---@return boolean success
 ---@return any ... results
@@ -102,7 +102,7 @@ end
 --- `cancel` resumes the task. It’s like sending a cancellation signal that the task needs to
 --- handle.
 ---
----@param task Task the task to cancel
+---@param task Coop.Task the task to cancel
 ---@return boolean success
 ---@return any ... results
 M.cancel = function(task)
@@ -125,7 +125,7 @@ end
 
 --- Returns the currently running task or nil.
 ---
----@return Task?
+---@return Coop.Task?
 M.running = function()
 	return running_task
 end
@@ -191,7 +191,7 @@ end
 
 --- Returns the status of a task’s thread.
 ---
----@param task Task the task
+---@param task Coop.Task the task
 ---@return string "running" | "suspended" | "normal" | "dead"
 M.status = function(task)
 	return coroutine.status(task.thread)

--- a/lua/coop/uv-utils.lua
+++ b/lua/coop/uv-utils.lua
@@ -13,7 +13,7 @@ M.sleep = function(ms)
 	local uv = require("coop.uv")
 	local copcall = require("coop.coroutine-utils").copcall
 
-	local timer = vim.uv.new_timer()
+	local timer = assert(vim.uv.new_timer())
 	local success, err = copcall(uv.timer_start, timer, ms, 0)
 	-- Safely close resources even in case of a cancellation error.
 	timer:stop()
@@ -63,7 +63,7 @@ end
 ---@param fd integer The file descriptor.
 ---@return Coop.StreamReader stream_reader The stream reader object.
 M.StreamReader.from_fd = function(fd)
-	local handle = vim.uv.new_pipe()
+	local handle = assert(vim.uv.new_pipe())
 	handle:open(fd)
 	return M.StreamReader.new(handle)
 end
@@ -145,7 +145,7 @@ end
 ---@param fd integer The file descriptor.
 ---@return Coop.StreamWriter stream_writer The stream writer object.
 M.StreamWriter.from_fd = function(fd)
-	local handle = vim.uv.new_pipe()
+	local handle = assert(vim.uv.new_pipe())
 	handle:open(fd)
 	return M.StreamWriter.new(handle)
 end

--- a/lua/coop/uv-utils.lua
+++ b/lua/coop/uv-utils.lua
@@ -28,7 +28,7 @@ end
 --- This is useful for a subprocess’s stdout and stderr..
 ---
 ---@class StreamReader
----@field handle uv_stream_t
+---@field handle uv.uv_stream_t
 ---@field buffer MpscQueue
 ---@field at_eof boolean
 ---@field read async fun(StreamReader): string?
@@ -39,7 +39,7 @@ M.StreamReader = {}
 
 --- Creates a stream reader.
 ---
----@param handle uv_stream_t The handle to a readable stream.
+---@param handle uv.uv_stream_t The handle to a readable stream.
 ---@return StreamReader stream_reader The stream writer object.
 M.StreamReader.new = function(handle)
 	if not vim.uv.is_readable(handle) then
@@ -118,7 +118,7 @@ end
 --- This is useful for a subprocess’s stdin.
 ---
 ---@class StreamWriter
----@field handle uv_stream_t
+---@field handle uv.uv_stream_t
 ---@field write async fun(StreamWriter, string)
 ---@field close async fun(StreamWriter)
 
@@ -126,7 +126,7 @@ M.StreamWriter = {}
 
 --- Creates a stream writer.
 ---
----@param handle uv_stream_t The handle to a writable stream.
+---@param handle uv.uv_stream_t The handle to a writable stream.
 ---@return StreamWriter stream_writer The stream writer object.
 M.StreamWriter.new = function(handle)
 	if not vim.uv.is_writable(handle) then

--- a/lua/coop/uv-utils.lua
+++ b/lua/coop/uv-utils.lua
@@ -27,20 +27,20 @@ end
 ---
 --- This is useful for a subprocess’s stdout and stderr..
 ---
----@class StreamReader
+---@class Coop.StreamReader
 ---@field handle uv.uv_stream_t
----@field buffer MpscQueue
+---@field buffer Coop.MpscQueue
 ---@field at_eof boolean
----@field read async fun(StreamReader): string?
----@field read_until_eof async fun(StreamReader): string
----@field close async fun(StreamReader)
+---@field read async fun(self: Coop.StreamReader): string?
+---@field read_until_eof async fun(self: Coop.StreamReader): string
+---@field close async fun(self: Coop.StreamReader)
 
 M.StreamReader = {}
 
 --- Creates a stream reader.
 ---
 ---@param handle uv.uv_stream_t The handle to a readable stream.
----@return StreamReader stream_reader The stream writer object.
+---@return Coop.StreamReader stream_reader The stream writer object.
 M.StreamReader.new = function(handle)
 	if not vim.uv.is_readable(handle) then
 		error("Can not create a stream reader, because the handle is not readable.")
@@ -61,7 +61,7 @@ end
 --- Creates a stream reader from a file descriptor.
 ---
 ---@param fd integer The file descriptor.
----@return StreamReader stream_reader The stream reader object.
+---@return Coop.StreamReader stream_reader The stream reader object.
 M.StreamReader.from_fd = function(fd)
 	local handle = vim.uv.new_pipe()
 	handle:open(fd)
@@ -71,7 +71,7 @@ end
 --- Reads data from the stream.
 ---
 ---@async
----@param self StreamReader
+---@param self Coop.StreamReader
 ---@return string? data The data read from the stream or nil if the stream is at EOF.
 M.StreamReader.read = function(self)
 	if self.at_eof then
@@ -89,7 +89,7 @@ end
 --- Reads remaining data from the stream.
 ---
 ---@async
----@param self StreamReader
+---@param self Coop.StreamReader
 ---@return string data The data read from the stream.
 M.StreamReader.read_until_eof = function(self)
 	local data = {}
@@ -108,7 +108,7 @@ end
 --- Closes the stream reader.
 ---
 ---@async
----@param self StreamReader
+---@param self Coop.StreamReader
 M.StreamReader.close = function(self)
 	return require("coop.uv").close(self.handle)
 end
@@ -117,17 +117,17 @@ end
 ---
 --- This is useful for a subprocess’s stdin.
 ---
----@class StreamWriter
+---@class Coop.StreamWriter
 ---@field handle uv.uv_stream_t
----@field write async fun(StreamWriter, string)
----@field close async fun(StreamWriter)
+---@field write async fun(self: Coop.StreamWriter, data: string)
+---@field close async fun(self: Coop.StreamWriter)
 
 M.StreamWriter = {}
 
 --- Creates a stream writer.
 ---
 ---@param handle uv.uv_stream_t The handle to a writable stream.
----@return StreamWriter stream_writer The stream writer object.
+---@return Coop.StreamWriter stream_writer The stream writer object.
 M.StreamWriter.new = function(handle)
 	if not vim.uv.is_writable(handle) then
 		error("Can not create a stream writer, because the handle is not writable.")
@@ -143,7 +143,7 @@ end
 --- Creates a stream writer from a file descriptor.
 ---
 ---@param fd integer The file descriptor.
----@return StreamWriter stream_writer The stream writer object.
+---@return Coop.StreamWriter stream_writer The stream writer object.
 M.StreamWriter.from_fd = function(fd)
 	local handle = vim.uv.new_pipe()
 	handle:open(fd)
@@ -153,7 +153,7 @@ end
 --- Writes data to the stream.
 ---
 ---@async
----@param self StreamWriter
+---@param self Coop.StreamWriter
 ---@param data string The data to write.
 ---@return string? err
 ---@return string? err_name
@@ -164,7 +164,7 @@ end
 --- Closes the stream writer.
 ---
 ---@async
----@param self StreamWriter
+---@param self Coop.StreamWriter
 M.StreamWriter.close = function(self)
 	return require("coop.uv").close(self.handle)
 end

--- a/lua/coop/uv.lua
+++ b/lua/coop/uv.lua
@@ -10,29 +10,6 @@ local coop = require("coop")
 
 ---@alias buffer string|string[]
 
----@alias uv_req_t uv_fs_t|uv_shutdown_t
----@class uv_fs_t
----@class uv_shutdown_t
-
--- https://neovim.io/doc/user/luvref.html#luv-contents
-
----@alias uv_handle_t uv_timer_t|uv_prepare_t|uv_check_t|uv_idle_t|uv_async_t|uv_poll_t|uv_signal_t|uv_process_t|uv_stream_t|uv_udp_t|uv_fs_event_t|uv_fs_pool_t
----@class uv_timer_t userdata
----@class uv_prepare_t userdata
----@class uv_check_t userdata
----@class uv_idle_t userdata
----@class uv_async_t userdata
----@class uv_poll_t userdata
----@class uv_signal_t userdata
----@class uv_process_t userdata
----@alias uv_stream_t uv_tcp_t|uv_pipe_t|uv_tty_t|userdata
----@class uv_tcp_t userdata
----@class uv_pipe_t userdata
----@class uv_tty_t userdata
----@class uv_udp_t userdata
----@alias uv_fs_event_t userdata
----@alias uv_fs_pool_t userdata
-
 --- Wraps the callback param with `vim.schedule_wrap`.
 ---
 --- This is useful for Libuv functions to ensure that their continuations can run `vim.api` functions without problems.
@@ -71,7 +48,7 @@ end
 --- https://neovim.io/doc/user/luvref.html#uv.close()
 ---
 ---@async
----@param handle uv_handle_t
+---@param handle uv.uv_handle_t
 M.close = function(handle)
 	return wrap(vim.uv.close)(handle)
 end
@@ -79,7 +56,7 @@ end
 --- https://neovim.io/doc/user/luvref.html#uv.timer_start()
 ---
 ---@async
----@param timer uv_timer_t
+---@param timer uv.uv_timer_t
 ---@param timeout integer
 ---@return integer? zero_or_fail
 ---@return string? err
@@ -104,7 +81,7 @@ end
 ---
 ---@param path string The path to the executable.
 ---@param options table
----@return uv_process_t handle
+---@return uv.uv_process_t handle
 ---@return integer pid
 ---@return Future future The future for the exit code and signal.
 M.spawn = function(path, options)
@@ -120,7 +97,7 @@ end
 --- https://neovim.io/doc/user/luvref.html#uv.shutdown()
 ---
 ---@async
----@param stream uv_stream_t
+---@param stream uv.uv_stream_t
 ---@return string? err
 ---@return string? err_name
 M.shutdown = function(stream)
@@ -144,7 +121,7 @@ end
 --- https://neovim.io/doc/user/luvref.html#uv.write()
 ---
 ---@async
----@param stream uv_stream_t
+---@param stream uv.uv_stream_t
 ---@param data buffer
 ---@return string? err
 ---@return string? err_name
@@ -260,7 +237,7 @@ end
 ---@async
 ---@param path string
 ---@return string? err
----@return uv_fs_t? success
+---@return uv.uv_fs_t? success
 M.fs_scandir = function(path)
 	return wrap(vim.uv.fs_scandir)(path)
 end
@@ -452,7 +429,7 @@ end
 ---@param path string
 ---@param entries? integer
 ---@return string? err
----@return luv_dir_t? dir
+---@return uv.luv_dir_t? dir
 M.fs_opendir = function(path, entries)
 	return wrap(vim.uv.fs_opendir, {
 		cleanup = function(err, dir)
@@ -466,7 +443,7 @@ end
 --- https://neovim.io/doc/user/luvref.html#uv.fs_readdir()
 ---
 ---@async
----@param dir luv_dir_t
+---@param dir uv.luv_dir_t
 ---@return string? err
 ---@return table? entries
 M.fs_readdir = function(dir)
@@ -476,7 +453,7 @@ end
 --- https://neovim.io/doc/user/luvref.html#uv.fs_closedir()
 ---
 ---@async
----@param dir luv_dir_t
+---@param dir uv.luv_dir_t
 ---@return string? err
 ---@return boolean? success
 M.fs_closedir = function(dir)

--- a/lua/coop/uv.lua
+++ b/lua/coop/uv.lua
@@ -38,7 +38,7 @@ end
 --- Wraps a Libuv function into a task function.
 ---
 ---@param f function
----@param cb2tf_opts? CbToTfOpts
+---@param cb2tf_opts? Coop.CbToTfOpts
 ---@param cb_pos? number|string the position of the callback parameter
 ---@return async function tf
 local wrap = function(f, cb2tf_opts, cb_pos)
@@ -83,7 +83,7 @@ end
 ---@param options table
 ---@return uv.uv_process_t handle
 ---@return integer pid
----@return Future future The future for the exit code and signal.
+---@return Coop.Future future The future for the exit code and signal.
 M.spawn = function(path, options)
 	local future = coop.Future.new()
 	local handle, pid = vim.uv.spawn(path, options, function(code, signal)

--- a/lua/coop/vim.lua
+++ b/lua/coop/vim.lua
@@ -1,23 +1,6 @@
 --- This module provides a task function version of vim.system.
 local M = {}
 
----@class vim.SystemOpts
----@field cwd? string
----@field env? table<string,string>
----@field clear_env? boolean
----@field stdin? string|string[]|boolean
----@field stdout? boolean|function
----@field stderr? boolean|function
----@field text? boolean
----@field timeout? integer
----@field detach? boolean
-
----@class vim.SystemCompleted
----@field code integer
----@field signal integer
----@field stdout string
----@field stderr string
-
 --- Runs a system command or throws an error if cmd cannot be run.
 ---
 ---@async

--- a/tests/coop/control_spec.lua
+++ b/tests/coop/control_spec.lua
@@ -77,7 +77,7 @@ describe("coop.control", function()
 		end)
 
 		it("protects from cancellation but still throws", function()
-			---@type Task
+			---@type Coop.Task
 			local internal_task = nil
 			local internal_task_done = false
 			local t = spawn(function()
@@ -101,7 +101,7 @@ describe("coop.control", function()
 		end)
 
 		it("completely ignores cancellation with copcall", function()
-			---@type Task
+			---@type Coop.Task
 			local internal_task = nil
 			local internal_task_done = false
 			local t = spawn(function()


### PR DESCRIPTION
This PR does a few things:
- Add luv and the vim runtime to the luals library paths - this avoids having to redefine types in coop. Note that all types from luv are under the `uv.` namespace.
- Namespace all types under `Coop.` IMHO this makes it easier to see where types are coming from in code that uses coop.
- Fix/improve some type annotations. The type of `std{in,out,err}` in `Coop.Process` was narrowed from any, and types that used `fun(TYPE)` where changed to `fun(param: TYPE)`.
- Add some asserts to `vim.uv` functions where luals was complaining about `needs null check`.

Please let me know what you think!

